### PR TITLE
Avoid touching synchronized objects during execution

### DIFF
--- a/ipc_benchmark.py
+++ b/ipc_benchmark.py
@@ -70,7 +70,8 @@ def ipc_worker(data, process_id, message_size, message_pattern, args, timestamps
     num_messages = args.message_count
     messages_processed = 0
     duration = args.duration
-    
+    output = []
+
     if duration == 0 and num_messages == 0:
         raise ValueError("Both duration and num_messages cannot be 0. Specify a positive value for at least one of them.")
     Rstart_time = time.time()
@@ -87,7 +88,7 @@ def ipc_worker(data, process_id, message_size, message_pattern, args, timestamps
             response[:] = data[:message_size]
             end_time = time.perf_counter()
 
-            timestamps.append({
+            output.append({
                 'capture_time': datetime.utcfromtimestamp(end_time).strftime('%Y-%m-%dT%H:%M:%S.%f'),
                 'process_id': process_id,
                 'start_time': start_time,
@@ -111,7 +112,7 @@ def ipc_worker(data, process_id, message_size, message_pattern, args, timestamps
             data[:message_size] = message
             end_time = time.time()
             print("capture data")
-            timestamps.append({
+            output.append({
                 'capture_time': datetime.utcfromtimestamp(end_time).strftime('%Y-%m-%dT%H:%M:%S.%f'),
                 'process_id': process_id,
                 'start_time': start_time,
@@ -125,6 +126,8 @@ def ipc_worker(data, process_id, message_size, message_pattern, args, timestamps
             messages_processed += 1
             if num_messages and messages_processed >= num_messages:
                 break
+
+    timestamps.extend(output)
 
 def create_shared_memory(size, posix=False):
     print("creating shared memory")


### PR DESCRIPTION
In `ipc_worker()`, the `timestamps` object is not a simple list -- accesses to it are coordinated between the multiple processes and, therefore, are quite expensive.  In fact, the cost of `timestamps.append()` dwarfs the cost of the rest of the loop!  This means that this benchmark, as it currently stands, is actually measuring the cost of Python's interprocess synchronization and not the cost of communication via shared memory.

This PR contains a small change which improves the measured result of the benchmark by about a factor of 20 by using a local list to accumulate the log results inside the loop and accessing `timestamps` only once, after the run is complete:
```
< Total Message Count: 231412.00
< Average Msg/s: 22737.00
< Average Throughput MB/s: 2.78
< Maximum Throughput MB/s: 3.23
< Minimum Throughput MB/s: 2.13
---
> Total Message Count: 4462742.00
> Average Msg/s: 205689.67
> Average Throughput MB/s: 36.37
> Maximum Throughput MB/s: 55.64
> Minimum Throughput MB/s: 0.00
```
However, you may want to reconsider how you post-process the information, as that too now takes about 20x longer:
```
< completed processing data, duration: 11.293455600738525
---
> completed processing data, duration: 227.2713053226471
```